### PR TITLE
feat: version API

### DIFF
--- a/cmd/faucet.go
+++ b/cmd/faucet.go
@@ -181,7 +181,8 @@ func runCmdHandler(cmd *cobra.Command, _ []string) error {
 	}
 
 	http.HandleFunc("/", faucet.ServeHTTP)
-	cmd.Printf("listening on :%d", port)
+	http.HandleFunc("/version", versionHTTP)
+	cmd.Printf("listening faucet on :%d", port)
 
 	return http.ListenAndServe(fmt.Sprintf(":%d", port), nil)
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -3,9 +3,11 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"strings"
 	"time"
 
+	"github.com/ignite/cli/v28/ignite/pkg/xhttp"
 	"github.com/spf13/cobra"
 
 	"github.com/ignite/faucet/version"
@@ -64,4 +66,27 @@ func checkNewVersion(ctx context.Context) {
 	}
 
 	fmt.Printf("⬆️ Gex %[1]v is available! To upgrade: https://github.com/ignite/gex/releases/%[1]v", next)
+}
+
+func versionHTTP(w http.ResponseWriter, r *http.Request) {
+	info, err := version.GetInfo(r.Context())
+	if err != nil {
+		responseError(w, http.StatusBadRequest, err)
+		return
+	}
+	responseSuccess(w, info)
+}
+
+type errResponse struct {
+	Error string `json:"error,omitempty"`
+}
+
+func responseError(w http.ResponseWriter, code int, err error) {
+	_ = xhttp.ResponseJSON(w, code, errResponse{
+		Error: err.Error(),
+	})
+}
+
+func responseSuccess(w http.ResponseWriter, info version.Info) {
+	_ = xhttp.ResponseJSON(w, http.StatusOK, info)
 }

--- a/version/version.go
+++ b/version/version.go
@@ -26,15 +26,15 @@ const (
 var Version = versionDev
 
 type Info struct {
-	Version         string
-	GoVersion       string
-	BuildDate       string
-	SourceHash      string
-	OS              string
-	Arch            string
-	Uname           string
-	CWD             string
-	BuildFromSource bool
+	Version         string `json:"version"`
+	GoVersion       string `json:"go_version"`
+	BuildDate       string `json:"build_date"`
+	SourceHash      string `json:"source_hash"`
+	OS              string `json:"os,omitempty"`
+	Arch            string `json:"arch,omitempty"`
+	Uname           string `json:"uname,omitempty"`
+	CWD             string `json:"cwd,omitempty"`
+	BuildFromSource bool   `json:"build_from_source,omitempty"`
 }
 
 // CheckNext checks whether there is a new version of Faucet.


### PR DESCRIPTION
### Description

Now we can check the faucet version from the API

http://localhost:8000/version

```json
{
  "version": "v0.0.2-dev",
  "go_version": "go version go1.23.3 darwin/arm64",
  "build_date": "2024-11-23T01:50:26Z",
  "source_hash": "a7742f78b99e489afab50932ba7dcd58bfe30ff4*",
  "os": "darwin",
  "arch": "arm64",
  "uname": "Darwin Air.meuintelbras.local 23.6.0 Darwin Kernel Version 23.6.0: Mon Jul 29 21:14:21 PDT 2024; root:xnu-10063.141.2~1/RELEASE_ARM64_T8103 arm64",
  "cwd": "/go/src/github.com/ignite/faucet",
  "build_from_source": true
}
```